### PR TITLE
feat: adds analytics

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        gtag: {
+          trackingID: 'GTM-5ZGHFCL',
+          anonymizeIP: false,
+        },
       }),
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.15",
+    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.15",
     "@docusaurus/preset-classic": "^2.0.0-beta.15",
     "@docusaurus/theme-classic": "^2.0.0-beta.15",
     "@docusaurus/theme-live-codeblock": "^2.0.0-beta.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,7 +1387,7 @@
     "@docusaurus/utils-validation" "2.0.0-beta.15"
     tslib "^2.3.1"
 
-"@docusaurus/plugin-google-gtag@2.0.0-beta.15":
+"@docusaurus/plugin-google-gtag@2.0.0-beta.15", "@docusaurus/plugin-google-gtag@^2.0.0-beta.15":
   version "2.0.0-beta.15"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.15.tgz#4db3330d302653e8541dc3cb86a4dbfef0cc96f8"
   integrity sha512-E5Rm3+dN7i3A9V5uq5sl9xTNA3aXsLwTZEA2SpOkY571dCpd+sfVvz1lR+KRY9Fy6ZHk8PqrNImgCWfIerRuZQ==


### PR DESCRIPTION
Adds a plugin for Google Tag Manager in Docusaurus. (needs node >14.0)

Also adds nvmrc set to lts/gallium (node 16 lts). 