### PR TITLE
chore(hitlnext): add warning that module is incompatible with converse api

### DIFF
--- a/docs/chatbot-management/agent-handover/human-in-the-loop/hitlnext.md
+++ b/docs/chatbot-management/agent-handover/human-in-the-loop/hitlnext.md
@@ -5,7 +5,11 @@ title: HITL Next
 
 --------------------
 
-This revamped HITL works on **all existing and future channels**. It supports all features of its predecessor and a few more :
+:::caution
+This module is **not** compatible with the Converse API
+:::
+
+This revamped HITL works on **all existing and future channels (except the Converse API)**. It supports all features of its predecessor and a few more :
 
 - Multi-agents ( _enterprise edition only_ )
 - Human handoff from any workflow


### PR DESCRIPTION
Self-explanatory.

Related to: https://github.com/botpress/botpress/pull/11922

Preview: https://documentation-git-llphitlnextconverseapiwarning-botpress-team.vercel.app/chatbot-management/agent-handover/human-in-the-loop/hitlnext