### PR TITLE
replaces gtag.js with gtm for more flexibility

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,8 +10,15 @@ const config = {
   onBrokenMarkdownLinks: "warn",
   favicon: "img/BlackSymbol.svg",
   organizationName: "Botpress/documentation", // Usually your GitHub org/user name.
+  plugins: [
+    [
+      require.resolve('docusaurus-gtm-plugin'),
+      {
+        id: 'GTM-5ZGHFCL', // GTM Container ID
+      }
+    ]
+  ],
   projectName: "botpress/documentation", // Usually your repo name.
-
   presets: [
     [
       "@docusaurus/preset-classic",
@@ -33,10 +40,6 @@ const config = {
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
-        },
-        gtag: {
-          trackingID: "GTM-5ZGHFCL",
-          anonymizeIP: false,
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.15",
     "@docusaurus/plugin-google-gtag": "^2.0.0-beta.15",
     "@docusaurus/preset-classic": "^2.0.0-beta.15",
     "@docusaurus/theme-classic": "^2.0.0-beta.15",
@@ -23,6 +22,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docusaurus-gtm-plugin": "^0.0.2",
     "file-loader": "^6.2.0",
     "front-matter": "^4.0.2",
     "prism-react-renderer": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,7 +1193,7 @@
     "@docsearch/css" "3.0.0-alpha.50"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-beta.15", "@docusaurus/core@^2.0.0-beta.15":
+"@docusaurus/core@2.0.0-beta.15":
   version "2.0.0-beta.15"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.15.tgz#1a3f8361803767072e56c77d60332c87e59f1ad0"
   integrity sha512-zXhhD0fApMSvq/9Pkm9DQxa//hGOXVCq9yMHiXOkI5D1tLec7PxtnaC5cLfGHljkN9cKIfRDYUVcG1gHymVfpA==
@@ -3571,6 +3571,11 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+docusaurus-gtm-plugin@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-gtm-plugin/-/docusaurus-gtm-plugin-0.0.2.tgz#f39864b54ca594e3281902c23b6df0763761602b"
+  integrity sha512-Xx/df0Ppd5SultlzUj9qlQk2lX9mNVfTb41juyBUPZ1Nc/5dNx+uN0VuLyF4JEObkDRrUY1EFo9fEUDo8I6QOQ==
 
 dom-converter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
https://measureschool.com/google-tag-manager-vs-global-site-tag/#:~:text=The%20first%20and%20major%20difference,a%20JavaScript-based%20tracking%20code. 

"While the gtag.js script only works with Google tools, Google Tag Manager allows you to send data to any tool that has a JavaScript-based tracking code. " 

This was preventing us from triggering non-google scripts, and why it appeared to be working. 

This also solves the issue of our analytics numbers not matching.