### PR TITLE
add pages for live agent handoff

### DIFF
--- a/pages/cloud/_meta.json
+++ b/pages/cloud/_meta.json
@@ -7,5 +7,6 @@
   "toolbox": "Toolbox",
   "channels": "Messaging Channels",
   "exporting-bot-data": "Exporting Bot Data",
-  "issues": "Issues"
+  "issues": "Issues",
+  "agent-handoff": "Live Agent Handoff"
 }

--- a/pages/cloud/agent-handoff/_meta.json
+++ b/pages/cloud/agent-handoff/_meta.json
@@ -1,0 +1,4 @@
+{
+  "zendesk": "Zendesk",
+  "other-platforms": "Other Platforms"
+}

--- a/pages/cloud/agent-handoff/other-platforms.mdx
+++ b/pages/cloud/agent-handoff/other-platforms.mdx
@@ -1,0 +1,9 @@
+# Agent Handoffs - Other Platforms
+
+Agent handoffs refer to the transition of a conversation from an automated bot to a live agent. In essence, it is the process by which a chat initiated on a platform like Whatsapp is transferred and handled by a professional agent through a different platform, in this instance, Zendesk. 
+
+You can also use this for automation processes that require human intervention. For example, if a user wants to cancel their subscription, you can use this to transfer the conversation to a live agent who can handle the cancellation conversation, then transfer the conversation back to the bot so that it may cancel the subscription.
+
+## Get Access
+Currently, our Agent Handoff module is in its BETA phase and only accessible on-demand. To gain access to this service, you need to reach out to our team.
+Reach out to our sales team to request on-demand access to the BETA. Just click [here](https://botpress.com/contact-us/?s=docs)

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -34,7 +34,7 @@ Return to your bot's dashboard. Here you will need to input your organizational 
 
 The bot will need the user's name and their email. This data will be saved to user variables.
 
-Create a 'user.name' and a 'user.email' variable. Confirmation of the information will be done using simple capture cards.
+Create a 'user.name' and a 'user.email' variable on the bottom-left variables panel. Make sure to select "User" as the scope. Confirmation of the information will be done using simple capture cards.
 
 ### Step 4: Enabling HITL Agent
 

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -4,7 +4,7 @@ Turn Botpress chats into Zendesk tickets, with a handy link added to the convers
 
 ## Getting Started
 
-In this guide, we will demonstrate how to establish Zendesk integration in order to facilitate live-bot interactions.
+In this guide, we will demonstrate how to set up the Zendesk integration to facilitate live interactions through the bot.
 
 <iframe
   data-youtube-iframe

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -38,7 +38,7 @@ Create a 'user.name' and a 'user.email' variable on the bottom-left variables pa
 
 ### Step 4: Enabling HITL Agent
 
-From the agent's menu in the bot, enable HITL Agent.
+From the "Agents" menu of the bot in Botpress Studio, click on the "HITL Agent" option, and then turn on the "Enable Agent" option.
 
 This menu will allow you to configure options such as choosing Zendesk as the desired integration. Also, you have the capability to design an 'end_conversation' intent that permits the user to opt out of speaking to a live agent.
 

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -28,7 +28,7 @@ Switch to the Zendesk admin center, and find the Zendesk API menu. Ensure you ha
 
 You will then need to create a distinct API token. Copy this for later use.
 
-Return to your bot's dashboard. Here you will need to input your organizational subdomain (for this instance, we will use 'botpresst'), your consistent Zendesk account email, and the copied API token. Ensure to save this configuration and activate the newly installed integration.
+Return to your bot's dashboard. Here you will need to input your organizational subdomain, your consistent Zendesk account email, and the copied API token. Ensure to save this configuration and activate the newly installed integration.
 
 ### Step 3: User Info Accumulation
 

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -2,9 +2,60 @@
 
 Turn Botpress chats into Zendesk tickets, with a handy link added to the conversation notes. Zendesk agents can communicate directly through Botpress chats, like Whatsapp or any other supported Botpress Channel.
 
+## Getting Access
+
+The Zendesk Integration for human handoff is currently in beta.
+Contact our sales team for early access. Just click [here](https://botpress.com/contact-us/?s=docs) to ask for access.
+
+## Getting Started
+
+In this guide, we will demonstrate how to establish Zendesk integration in order to facilitate live-bot interactions.
+
+<iframe
+  data-youtube-iframe
+  width="720"
+  height="360"
+  src="https://www.youtube.com/embed/KR87xwsh33Y?si=KIv2yuNFwZxHtJzE"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>
 
 
-## Get Access
-Installation instructions are coming soon.
+### Step 1: Add Zendesk Integration 
 
-Contact our sales team for early beta access. Just click [here](https://botpress.com/contact-us/?s=docs).
+Firstly, locate your bot's dashboard and click on the integrations tab. Use the search bar to find and select the Zendesk Integration. Once found, install this onto your bot.
+
+### Step 2: Setting up Zendesk Integration
+
+Switch to the Zendesk admin center, and find the Zendesk API menu. Ensure you have both password and token access enabled.
+
+You will then need to create a distinct API token. Copy this for later use.
+
+Return to your bot's dashboard. Here you will need to input your organizational subdomain (for this instance, we will use 'botpresst'), your consistent Zendesk account email, and the copied API token. Ensure to save this configuration and activate the newly installed integration.
+
+### Step 3: User Info Accumulation
+
+The bot will need the user's name and their email. This data will be saved to user variables.
+
+Create a 'user.name' and a 'user.email' variable. Confirmation of the information will be done using simple capture cards.
+
+### Step 4: Enabling HITL Agent
+
+From the agent's menu in the bot, enable HITL Agent.
+
+This menu will allow you to configure options such as choosing Zendesk as the desired integration. Also, you have the capability to design an 'end_conversation' intent that permits the user to opt out of speaking to a live agent.
+
+Most settings are default, you may choose to modify them to your preference.
+
+### Step 5: Activating HITL
+
+In a new node, insert a Start HITL card which triggers the bot into initiating a live agent.
+
+The card will automatically summarize the conversation and provide a transcript for the live agent in the Zendesk menu.
+
+### Step 6: Test the Configuration
+
+Now that everything has been configured accordingly, proceed to test the set-up. Prior to testing, ensure the most recent version of your bot is up and running.
+

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -1,0 +1,10 @@
+# Zendesk Agent Handoff (Beta)
+
+Turn Botpress chats into Zendesk tickets, with a handy link added to the conversation notes. Zendesk agents can communicate directly through Botpress chats, like Whatsapp or any other supported Botpress Channel.
+
+
+
+## Get Access
+Installation instructions are coming soon.
+
+Contact our sales team for early beta access. Just click [here](https://botpress.com/contact-us/?s=docs).

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -1,6 +1,6 @@
 # Zendesk Agent Handoff (Beta)
 
-Turn Botpress chats into Zendesk tickets, with a handy link added to the conversation notes. Zendesk agents can communicate directly through Botpress chats, like Whatsapp or any other supported Botpress Channel.
+Turn Botpress chats into Zendesk tickets, with a handy link added to the conversation notes. A Zendesk agent can communicate directly with the user on the same conversation initially handled by the bot on any channels supported by Botpress (e.g. web chat, Whatsapp, Messenger, etc.)
 
 ## Getting Started
 

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -2,11 +2,6 @@
 
 Turn Botpress chats into Zendesk tickets, with a handy link added to the conversation notes. Zendesk agents can communicate directly through Botpress chats, like Whatsapp or any other supported Botpress Channel.
 
-## Getting Access
-
-The Zendesk Integration for human handoff is currently in beta.
-Contact our sales team for early access. Just click [here](https://botpress.com/contact-us/?s=docs) to ask for access.
-
 ## Getting Started
 
 In this guide, we will demonstrate how to establish Zendesk integration in order to facilitate live-bot interactions.

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -46,7 +46,7 @@ Most settings are default, you may choose to modify them to your preference.
 
 ### Step 5: Activating HITL
 
-In a new node, insert a Start HITL card which triggers the bot into initiating a live agent.
+Add a new node to your bot in Botpress Studio and then insert a "Start HITL" card, which will trigger the bot into initiating a live agent.
 
 The card will automatically summarize the conversation and provide a transcript for the live agent in the Zendesk menu.
 

--- a/pages/cloud/agent-handoff/zendesk.mdx
+++ b/pages/cloud/agent-handoff/zendesk.mdx
@@ -40,7 +40,7 @@ Create a 'user.name' and a 'user.email' variable on the bottom-left variables pa
 
 From the "Agents" menu of the bot in Botpress Studio, click on the "HITL Agent" option, and then turn on the "Enable Agent" option.
 
-This menu will allow you to configure options such as choosing Zendesk as the desired integration. Also, you have the capability to design an 'end_conversation' intent that permits the user to opt out of speaking to a live agent.
+This menu will allow you to configure options such as choosing Zendesk as the desired integration. Also, you have the capability to design an 'end_conversation' intent that permits the user to opt out of speaking to a live agent. To do so, pick a global intent from the dropdown, for instance "Cancel". 
 
 Most settings are default, you may choose to modify them to your preference.
 


### PR DESCRIPTION
zendesk page + other platforms, all pointing to the sales form.


Page one : https://documentation-git-phaddhitlpage.botpress.sh/docs/cloud/agent-handoff/zendesk/
Page two : https://documentation-git-phaddhitlpage.botpress.sh/docs/cloud/agent-handoff/other-platforms/
Preview of navigation : 
![image](https://github.com/botpress/documentation/assets/87815239/5fc796c8-3755-4b47-afed-1f462b6a6950)
