### PR TITLE
fixes broken link

### DIFF
--- a/pages/developers/webchat/controlling-webchat-using-js.mdx
+++ b/pages/developers/webchat/controlling-webchat-using-js.mdx
@@ -103,7 +103,7 @@ You can see examples of all of the message types you can send to the chatbot [he
 ### Listening to Widget Events
 
 This function lets you listen for certain events happening in the chat and then do something when they happen. It's like setting up a watch for specific actions.
-You can find the list of events [here](../toolbox/events-triggers#webchat-lifecycle-and-events).
+You can find the list of events [here](../../cloud/toolbox/events-triggers#webchat-lifecycle-and-events).
 
 ```js
 window.botpressWebChat.onEvent(

--- a/pages/developers/webchat/controlling-webchat-using-js.mdx
+++ b/pages/developers/webchat/controlling-webchat-using-js.mdx
@@ -90,7 +90,7 @@ To load a conversation, you must provide the conversation ID. You can get the co
 
 ### Sending messages or instructions from your website
 
-You can use the `sendPayload` function to send a specific message (or instruction) to the chatbot. For sending instructions, please refer to [Triggers](../toolbox/events-triggers#webchat-triggers).
+You can use the `sendPayload` function to send a specific message (or instruction) to the chatbot. For sending instructions, please refer to [Triggers](../../cloud/toolbox/events-triggers#webchat-triggers).
 
 ```js
 window.botpressWebChat.sendPayload({ type: 'text', text: 'I am a message sent through code' })


### PR DESCRIPTION
Fixes two link typos on : https://documentation-git-ptrckbp-patch-3.botpress.sh/docs/developers/webchat/controlling-webchat-using-js/#sending-messages-or-instructions-from-your-website