### PR TITLE
feat(instagram): add missing scope for customizing bot

### DIFF
--- a/pages/cloud/channels/slack.mdx
+++ b/pages/cloud/channels/slack.mdx
@@ -24,7 +24,7 @@ The Slack integration has the following settings:
 ### Bot Token
 
 1. In the left sidebar, click on **Features** > **OAuth & Permissions**
-1. Scroll down to the **Scope** > **Bot Token Scopes** section, click **Add an OAuth Scope**. Select `chat:write` and `chat:write.customize` options from the list.
+1. Scroll down to the **Scope** > **Bot Token Scopes** section, click **Add an OAuth Scope**. Select both `chat:write` and `chat:write.customize` options from the list.
 1. Scroll up and click the **Install to Workspace** button in the **OAuth Tokens for Your Workspace** section
 1. In the next screen, your app will request access to your Slack workspace. Click **Allow**.
 1. In the **OAuth & Permissions > OAuth Tokens for Your Workspace** section, copy the **Bot User OAuth Token**.

--- a/pages/cloud/channels/slack.mdx
+++ b/pages/cloud/channels/slack.mdx
@@ -24,7 +24,7 @@ The Slack integration has the following settings:
 ### Bot Token
 
 1. In the left sidebar, click on **Features** > **OAuth & Permissions**
-1. Scroll down to the **Scope** > **Bot Token Scopes** section, click **Add an OAuth Scope**. Select the `chat:write` option from the list.
+1. Scroll down to the **Scope** > **Bot Token Scopes** section, click **Add an OAuth Scope**. Select `chat:write` and `chat:write.customize` options from the list.
 1. Scroll up and click the **Install to Workspace** button in the **OAuth Tokens for Your Workspace** section
 1. In the next screen, your app will request access to your Slack workspace. Click **Allow**.
 1. In the **OAuth & Permissions > OAuth Tokens for Your Workspace** section, copy the **Bot User OAuth Token**.


### PR DESCRIPTION
[This PR](https://github.com/botpress/botpress/pull/12907) introduces a new feature that allows users to configure the Slack bot's avatar URL and name directly from the interface. This enhancement aims to provide greater flexibility and personalization for users configuring the Slack bot.

The bot scope [chat:write.customize](https://api.slack.com/scopes/chat:write.customize) must be added as a scope for this feature to work. If the scope is not added, no error is thrown, the params are just ignored by Slack.