### PR TITLE
docs: remove agent handoff catchall page

### DIFF
--- a/pages/cloud/agent-handoff/_meta.json
+++ b/pages/cloud/agent-handoff/_meta.json
@@ -1,4 +1,3 @@
 {
-  "zendesk": "Zendesk",
-  "other-platforms": "Other Platforms"
+  "zendesk": "Zendesk"
 }

--- a/pages/cloud/agent-handoff/other-platforms.mdx
+++ b/pages/cloud/agent-handoff/other-platforms.mdx
@@ -1,9 +1,0 @@
-# Agent Handoffs - Other Platforms
-
-Agent handoffs refer to the transition of a conversation from an automated bot to a live agent. In essence, it is the process by which a chat initiated on a platform like Whatsapp is transferred and handled by a professional agent through a different platform, in this instance, Zendesk. 
-
-You can also use this for automation processes that require human intervention. For example, if a user wants to cancel their subscription, you can use this to transfer the conversation to a live agent who can handle the cancellation conversation, then transfer the conversation back to the bot so that it may cancel the subscription.
-
-## Get Access
-Currently, our Agent Handoff module is in its BETA phase and only accessible on-demand. To gain access to this service, you need to reach out to our team.
-Reach out to our sales team to request on-demand access to the BETA. Just click [here](https://botpress.com/contact-us/?s=docs)


### PR DESCRIPTION
removes https://botpress.com/docs/cloud/agent-handoff/other-platforms/#get-access, requested by sales